### PR TITLE
Add transparent PNG window feature

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const isDev = require('electron-is-dev');
+const { setupTransparentWindowHandlers } = require('./transparentWindow');
 
 // Disable GPU acceleration to prevent GPU process errors
 app.disableHardwareAcceleration();
@@ -35,7 +36,10 @@ function createWindow() {
   });
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  createWindow();
+  setupTransparentWindowHandlers();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -3,5 +3,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electron', {
   openDirectory: () => ipcRenderer.invoke('dialog:openDirectory'),
   readDirectory: (path) => ipcRenderer.invoke('fs:readDirectory', path),
-  readFile: (path) => ipcRenderer.invoke('fs:readFile', path)
+  readFile: (path) => ipcRenderer.invoke('fs:readFile', path),
+  openTransparentWindow: (imagePath, imageData) => 
+    ipcRenderer.invoke('window:openTransparent', imagePath, imageData)
 });

--- a/electron/preloadTransparent.js
+++ b/electron/preloadTransparent.js
@@ -4,6 +4,8 @@ contextBridge.exposeInMainWorld('transparentWindow', {
   loadImage: (callback) => {
     ipcRenderer.on('load-image', (_, data) => callback(data));
   },
-  startDrag: () => ipcRenderer.send('window:startDrag'),
+  startDrag: () => ipcRenderer.sendSync('window:dragStart'),
+  drag: (mouseX, mouseY, offsetX, offsetY) => 
+    ipcRenderer.send('window:drag', { mouseX, mouseY, offsetX, offsetY }),
   close: () => ipcRenderer.send('window:close')
 });

--- a/electron/preloadTransparent.js
+++ b/electron/preloadTransparent.js
@@ -1,0 +1,9 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('transparentWindow', {
+  loadImage: (callback) => {
+    ipcRenderer.on('load-image', (_, data) => callback(data));
+  },
+  startDrag: () => ipcRenderer.send('window:startDrag'),
+  close: () => ipcRenderer.send('window:close')
+});

--- a/electron/transparentWindow.js
+++ b/electron/transparentWindow.js
@@ -1,0 +1,96 @@
+const { BrowserWindow, ipcMain, screen } = require('electron');
+const path = require('path');
+const isDev = require('electron-is-dev');
+
+let transparentWindows = new Map();
+
+function createTransparentWindow(imagePath, imageData) {
+  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
+  
+  // Create a new BrowserWindow with transparent background and no frame
+  const transparentWindow = new BrowserWindow({
+    width: 400,
+    height: 400,
+    transparent: true,
+    frame: false,
+    resizable: false,
+    skipTaskbar: true,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preloadTransparent.js')
+    }
+  });
+
+  // Position the window in the center of the screen
+  transparentWindow.setPosition(
+    Math.floor(width / 2 - 200),
+    Math.floor(height / 2 - 200)
+  );
+
+  // Load the transparent window HTML
+  transparentWindow.loadURL(
+    isDev
+      ? 'http://localhost:3000/transparent.html'
+      : `file://${path.join(__dirname, '../build/transparent.html')}`
+  );
+
+  // Store the window reference
+  transparentWindows.set(imagePath, transparentWindow);
+  
+  // When window is ready, send the image data
+  transparentWindow.webContents.on('did-finish-load', () => {
+    transparentWindow.webContents.send('load-image', {
+      imageData,
+      imagePath
+    });
+  });
+
+  // Remove window reference when closed
+  transparentWindow.on('closed', () => {
+    transparentWindows.delete(imagePath);
+  });
+
+  return transparentWindow;
+}
+
+function setupTransparentWindowHandlers() {
+  // Handle opening a transparent window
+  ipcMain.handle('window:openTransparent', async (_, imagePath, imageData) => {
+    // If window for this image already exists, focus it instead of creating a new one
+    if (transparentWindows.has(imagePath)) {
+      transparentWindows.get(imagePath).focus();
+      return { success: true };
+    }
+    
+    try {
+      createTransparentWindow(imagePath, imageData);
+      return { success: true };
+    } catch (error) {
+      console.error('Error creating transparent window:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
+  // Handle window dragging
+  ipcMain.on('window:startDrag', (event) => {
+    const webContents = event.sender;
+    const win = BrowserWindow.fromWebContents(webContents);
+    if (win) {
+      win.startWindowDrag();
+    }
+  });
+
+  // Handle window close
+  ipcMain.on('window:close', (event) => {
+    const webContents = event.sender;
+    const win = BrowserWindow.fromWebContents(webContents);
+    if (win) {
+      win.close();
+    }
+  });
+}
+
+module.exports = {
+  setupTransparentWindowHandlers
+};

--- a/electron/transparentWindow.js
+++ b/electron/transparentWindow.js
@@ -74,11 +74,7 @@ function setupTransparentWindowHandlers() {
 
   // Handle window dragging using manual positioning
   ipcMain.on('window:dragStart', (event) => {
-    const webContents = event.sender;
-    const win = BrowserWindow.fromWebContents(webContents);
-    if (!win) return;
-    
-    // Just acknowledge that dragging has started
+    // Just acknowledge the drag start
     event.returnValue = true;
   });
   
@@ -87,8 +83,7 @@ function setupTransparentWindowHandlers() {
     const win = BrowserWindow.fromWebContents(webContents);
     if (!win) return;
     
-    // Calculate new position
-    const [x, y] = win.getPosition();
+    // Set the window position based on mouse position and offset
     win.setPosition(mouseX - offsetX, mouseY - offsetY);
   });
 

--- a/electron/transparentWindow.js
+++ b/electron/transparentWindow.js
@@ -72,13 +72,24 @@ function setupTransparentWindowHandlers() {
     }
   });
 
-  // Handle window dragging
-  ipcMain.on('window:startDrag', (event) => {
+  // Handle window dragging using manual positioning
+  ipcMain.on('window:dragStart', (event) => {
     const webContents = event.sender;
     const win = BrowserWindow.fromWebContents(webContents);
-    if (win) {
-      win.startWindowDrag();
-    }
+    if (!win) return;
+    
+    // Just acknowledge that dragging has started
+    event.returnValue = true;
+  });
+  
+  ipcMain.on('window:drag', (event, { mouseX, mouseY, offsetX, offsetY }) => {
+    const webContents = event.sender;
+    const win = BrowserWindow.fromWebContents(webContents);
+    if (!win) return;
+    
+    // Calculate new position
+    const [x, y] = win.getPosition();
+    win.setPosition(mouseX - offsetX, mouseY - offsetY);
   });
 
   // Handle window close

--- a/public/transparent.html
+++ b/public/transparent.html
@@ -15,7 +15,6 @@
       }
 
       body {
-        -webkit-app-region: no-drag;
         user-select: none;
       }
 
@@ -39,10 +38,6 @@
         bottom: 0;
         -webkit-user-drag: none;
       }
-
-      .draggable {
-        -webkit-app-region: drag;
-      }
     </style>
   </head>
   <body>
@@ -59,6 +54,11 @@
       
       let isOverNonTransparentPixel = false;
       let imagePath = '';
+      
+      // For dragging
+      let isDragging = false;
+      let dragOffsetX = 0;
+      let dragOffsetY = 0;
 
       // Listen for image data from the main process
       window.transparentWindow.loadImage(({ imageData, imagePath: path }) => {
@@ -94,7 +94,6 @@
             // Mouse is outside image bounds
             isOverNonTransparentPixel = false;
             document.body.style.cursor = 'default';
-            imageEl.classList.remove('draggable');
             return;
           }
 
@@ -108,13 +107,21 @@
           // Check alpha channel (index 3) for transparency
           isOverNonTransparentPixel = pixelData[3] > 0;
           
-          // Update cursor and draggable state based on transparency
+          // Update cursor based on transparency
           if (isOverNonTransparentPixel) {
             document.body.style.cursor = 'move';
-            imageEl.classList.add('draggable');
           } else {
             document.body.style.cursor = 'default';
-            imageEl.classList.remove('draggable');
+          }
+          
+          // Handle dragging motion
+          if (isDragging && isOverNonTransparentPixel) {
+            window.transparentWindow.drag(
+              e.screenX, 
+              e.screenY, 
+              dragOffsetX, 
+              dragOffsetY
+            );
           }
         });
       }
@@ -126,19 +133,31 @@
         }
       });
 
-      // Window interactions
-      let isDragging = false;
-
-      // Start drag on mousedown if over non-transparent part
+      // Window dragging with manual positioning
       document.addEventListener('mousedown', (e) => {
-        // Only allow starting drag on non-transparent pixels
         if (isOverNonTransparentPixel) {
+          // Start drag if clicked on non-transparent pixel
           isDragging = true;
+          
+          // Store the current mouse position and offset
+          const rect = imageEl.getBoundingClientRect();
+          dragOffsetX = e.clientX - rect.left;
+          dragOffsetY = e.clientY - rect.top;
+          
           window.transparentWindow.startDrag();
+          
+          // Prevent default behaviors
+          e.preventDefault();
         }
       });
 
+      // Stop dragging on mouse up
       document.addEventListener('mouseup', () => {
+        isDragging = false;
+      });
+      
+      // Also stop dragging if mouse leaves the window
+      document.addEventListener('mouseleave', () => {
         isDragging = false;
       });
     </script>

--- a/public/transparent.html
+++ b/public/transparent.html
@@ -57,8 +57,12 @@
       
       // For dragging
       let isDragging = false;
+      let dragStarted = false;
+      let dragStartX = 0;
+      let dragStartY = 0;
       let dragOffsetX = 0;
       let dragOffsetY = 0;
+      let initialClickOnNonTransparent = false;
 
       // Listen for image data from the main process
       window.transparentWindow.loadImage(({ imageData, imagePath: path }) => {
@@ -76,90 +80,107 @@
           ctx.drawImage(imageEl, 0, 0);
 
           // Initialize tracking
-          updateHitTests();
+          initializeInteractions();
         };
       });
 
-      // Handle mouse move for pixel transparency detection
-      function updateHitTests() {
+      // Check if a pixel at the given coordinates is transparent
+      function isPixelTransparent(x, y) {
+        const rect = imageEl.getBoundingClientRect();
+        
+        // Check if coordinates are outside image bounds
+        if (
+          x < rect.left ||
+          x > rect.right ||
+          y < rect.top ||
+          y > rect.bottom
+        ) {
+          return true;
+        }
+
+        // Convert window coordinates to image coordinates
+        const imgX = Math.floor(((x - rect.left) / rect.width) * hitTestCanvas.width);
+        const imgY = Math.floor(((y - rect.top) / rect.height) * hitTestCanvas.height);
+        
+        // Check if coordinates are within canvas bounds
+        if (
+          imgX < 0 || 
+          imgX >= hitTestCanvas.width || 
+          imgY < 0 || 
+          imgY >= hitTestCanvas.height
+        ) {
+          return true;
+        }
+
+        // Get pixel data (RGBA)
+        const pixelData = ctx.getImageData(imgX, imgY, 1, 1).data;
+        
+        // Check alpha channel (index 3) for transparency
+        return pixelData[3] === 0;
+      }
+
+      function initializeInteractions() {
+        // Handle mouse move for pixel transparency detection and dragging
         document.addEventListener('mousemove', (e) => {
-          // Get mouse position relative to the image
-          const rect = imageEl.getBoundingClientRect();
-          if (
-            e.clientX < rect.left ||
-            e.clientX > rect.right ||
-            e.clientY < rect.top ||
-            e.clientY > rect.bottom
-          ) {
-            // Mouse is outside image bounds
-            isOverNonTransparentPixel = false;
-            document.body.style.cursor = 'default';
-            return;
-          }
-
-          // Calculate position in the original image coordinates
-          const x = Math.floor(((e.clientX - rect.left) / rect.width) * hitTestCanvas.width);
-          const y = Math.floor(((e.clientY - rect.top) / rect.height) * hitTestCanvas.height);
-
-          // Get pixel data (RGBA)
-          const pixelData = ctx.getImageData(x, y, 1, 1).data;
-          
-          // Check alpha channel (index 3) for transparency
-          isOverNonTransparentPixel = pixelData[3] > 0;
-          
-          // Update cursor based on transparency
-          if (isOverNonTransparentPixel) {
-            document.body.style.cursor = 'move';
-          } else {
-            document.body.style.cursor = 'default';
-          }
-          
-          // Handle dragging motion
-          if (isDragging && isOverNonTransparentPixel) {
+          // If dragging is in progress, always move the window regardless of current pixel
+          if (isDragging) {
             window.transparentWindow.drag(
               e.screenX, 
               e.screenY, 
               dragOffsetX, 
               dragOffsetY
             );
+            return;
+          }
+          
+          // Not dragging, just check if we're over a non-transparent pixel
+          isOverNonTransparentPixel = !isPixelTransparent(e.clientX, e.clientY);
+          
+          // Update cursor based on transparency
+          document.body.style.cursor = isOverNonTransparentPixel ? 'move' : 'default';
+        });
+
+        // Initialize window dragging
+        document.addEventListener('mousedown', (e) => {
+          initialClickOnNonTransparent = !isPixelTransparent(e.clientX, e.clientY);
+          
+          if (initialClickOnNonTransparent) {
+            // Start drag if clicked on non-transparent pixel
+            isDragging = true;
+            
+            // Calculate and store the click offset relative to the window
+            const rect = imageEl.getBoundingClientRect();
+            dragOffsetX = e.clientX - rect.left;
+            dragOffsetY = e.clientY - rect.top;
+            
+            // Tell the main process dragging has started
+            window.transparentWindow.startDrag();
+            
+            // Prevent default behaviors
+            e.preventDefault();
+          }
+          // If clicked on transparent area, do nothing so the click passes through
+        });
+
+        // Handle drag end
+        window.addEventListener('mouseup', () => {
+          isDragging = false;
+          initialClickOnNonTransparent = false;
+        });
+
+        // Also handle mouseup outside the window
+        window.addEventListener('blur', () => {
+          isDragging = false;
+          initialClickOnNonTransparent = false;
+        });
+        
+        // Listen for key press to close window (only when over non-transparent pixels)
+        document.addEventListener('keydown', (e) => {
+          if (e.key.toLowerCase() === 'w' && isOverNonTransparentPixel) {
+            window.transparentWindow.close();
           }
         });
       }
-
-      // Listen for key press to close window (only when over non-transparent pixels)
-      document.addEventListener('keydown', (e) => {
-        if (e.key.toLowerCase() === 'w' && isOverNonTransparentPixel) {
-          window.transparentWindow.close();
-        }
-      });
-
-      // Window dragging with manual positioning
-      document.addEventListener('mousedown', (e) => {
-        if (isOverNonTransparentPixel) {
-          // Start drag if clicked on non-transparent pixel
-          isDragging = true;
-          
-          // Store the current mouse position and offset
-          const rect = imageEl.getBoundingClientRect();
-          dragOffsetX = e.clientX - rect.left;
-          dragOffsetY = e.clientY - rect.top;
-          
-          window.transparentWindow.startDrag();
-          
-          // Prevent default behaviors
-          e.preventDefault();
-        }
-      });
-
-      // Stop dragging on mouse up
-      document.addEventListener('mouseup', () => {
-        isDragging = false;
-      });
-      
-      // Also stop dragging if mouse leaves the window
-      document.addEventListener('mouseleave', () => {
-        isDragging = false;
-      });
     </script>
   </body>
 </html>

--- a/public/transparent.html
+++ b/public/transparent.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>PNG Viewer - Transparent Window</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: transparent;
+      }
+
+      body {
+        -webkit-app-region: no-drag;
+        user-select: none;
+      }
+
+      #image-container {
+        position: absolute;
+        display: block;
+        height: 100%;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #png-image {
+        position: absolute;
+        max-width: 100%;
+        max-height: 100%;
+        display: none;
+        margin: auto;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        -webkit-user-drag: none;
+      }
+
+      .draggable {
+        -webkit-app-region: drag;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="image-container">
+      <img id="png-image" alt="PNG Image" />
+    </div>
+    <canvas id="hit-test-canvas" style="display: none;"></canvas>
+
+    <script>
+      // Get elements
+      const imageEl = document.getElementById('png-image');
+      const hitTestCanvas = document.getElementById('hit-test-canvas');
+      const ctx = hitTestCanvas.getContext('2d');
+      
+      let isOverNonTransparentPixel = false;
+      let imagePath = '';
+
+      // Listen for image data from the main process
+      window.transparentWindow.loadImage(({ imageData, imagePath: path }) => {
+        imagePath = path;
+        imageEl.src = imageData;
+        imageEl.style.display = 'block';
+        
+        // Once image is loaded, prepare hit-testing canvas
+        imageEl.onload = () => {
+          // Size canvas to match image
+          hitTestCanvas.width = imageEl.naturalWidth;
+          hitTestCanvas.height = imageEl.naturalHeight;
+          
+          // Draw the image onto the canvas for pixel data access
+          ctx.drawImage(imageEl, 0, 0);
+
+          // Initialize tracking
+          updateHitTests();
+        };
+      });
+
+      // Handle mouse move for pixel transparency detection
+      function updateHitTests() {
+        document.addEventListener('mousemove', (e) => {
+          // Get mouse position relative to the image
+          const rect = imageEl.getBoundingClientRect();
+          if (
+            e.clientX < rect.left ||
+            e.clientX > rect.right ||
+            e.clientY < rect.top ||
+            e.clientY > rect.bottom
+          ) {
+            // Mouse is outside image bounds
+            isOverNonTransparentPixel = false;
+            document.body.style.cursor = 'default';
+            imageEl.classList.remove('draggable');
+            return;
+          }
+
+          // Calculate position in the original image coordinates
+          const x = Math.floor(((e.clientX - rect.left) / rect.width) * hitTestCanvas.width);
+          const y = Math.floor(((e.clientY - rect.top) / rect.height) * hitTestCanvas.height);
+
+          // Get pixel data (RGBA)
+          const pixelData = ctx.getImageData(x, y, 1, 1).data;
+          
+          // Check alpha channel (index 3) for transparency
+          isOverNonTransparentPixel = pixelData[3] > 0;
+          
+          // Update cursor and draggable state based on transparency
+          if (isOverNonTransparentPixel) {
+            document.body.style.cursor = 'move';
+            imageEl.classList.add('draggable');
+          } else {
+            document.body.style.cursor = 'default';
+            imageEl.classList.remove('draggable');
+          }
+        });
+      }
+
+      // Listen for key press to close window (only when over non-transparent pixels)
+      document.addEventListener('keydown', (e) => {
+        if (e.key.toLowerCase() === 'w' && isOverNonTransparentPixel) {
+          window.transparentWindow.close();
+        }
+      });
+
+      // Window interactions
+      let isDragging = false;
+
+      // Start drag on mousedown if over non-transparent part
+      document.addEventListener('mousedown', (e) => {
+        // Only allow starting drag on non-transparent pixels
+        if (isOverNonTransparentPixel) {
+          isDragging = true;
+          window.transparentWindow.startDrag();
+        }
+      });
+
+      document.addEventListener('mouseup', () => {
+        isDragging = false;
+      });
+    </script>
+  </body>
+</html>

--- a/src/components/ImageThumbnail.js
+++ b/src/components/ImageThumbnail.js
@@ -9,8 +9,21 @@ function ImageThumbnail({ image, src }) {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
+  const handleClick = async () => {
+    if (!src) return; // Don't do anything if image isn't loaded yet
+    
+    try {
+      await window.electron.openTransparentWindow(image.path, src);
+    } catch (error) {
+      console.error('Error opening transparent window:', error);
+    }
+  };
+
   return (
-    <div className="border rounded-lg overflow-hidden bg-white shadow-sm hover:shadow-md transition-shadow">
+    <div 
+      className="border rounded-lg overflow-hidden bg-white shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+      onClick={handleClick}
+    >
       <div className="h-40 bg-gray-100 flex items-center justify-center">
         {src ? (
           <img 


### PR DESCRIPTION
## Feature: Transparent PNG Window

This PR implements a new feature that allows users to view PNG images in a separate frameless window when they click on a thumbnail.

### Key Features:
- Click on a thumbnail to open a transparent window showing only the PNG
- Window is only interactable on non-transparent pixels of the PNG
- Click-through works on transparent areas (clicks pass through to windows/content underneath)
- Window can be closed by pressing 'W' key when the mouse is over non-transparent pixels
- Window can be dragged by clicking and dragging on non-transparent pixels

### Implementation Details:
- Created a separate HTML page for the transparent window display
- Used canvas to analyze pixel transparency for hit testing
- Implemented frameless window with transparent background in Electron
- Added IPC communication between main window and transparent window

### Notes:
- Window size currently defaults to 400x400, with the image centered and scaled to fit
- Only works with PNG images that have transparency