### PR TITLE
Fix zoom behavior and add cutout feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Electron + React application for browsing PNG files in a selected folder.
 - Display thumbnails of PNG images
 - Show image file name and size
 - Zoom in/out of images using the mouse wheel (improved zooming centered on cursor)
-- Create cutout effect with "R" key for creative image presentations
+- Real crop feature using "R" key that physically crops the window to selected area
 - Drag transparent PNGs by their visible parts
 - Simple and intuitive user interface
 
@@ -40,7 +40,16 @@ The application will launch and you can click the "Select PNG Folder" button to 
 - Use the mouse wheel to zoom in/out of the image (zoom centers on cursor position)
 - Drag the image by clicking and holding on any non-transparent part
 - Press 'W' key while hovering over the image to close the window
-- Press 'R' key to toggle the cutout mode (shows only the top half of the image)
+
+### Using the Crop Tool
+
+1. Press 'R' key to activate the crop tool
+2. Draw a crop region by clicking and dragging on the image
+3. Adjust the crop by dragging the handles on the corners and edges
+4. Press 'Enter' to apply the crop - this will physically resize the window to show only the cropped area
+5. Press 'Escape' to cancel the crop operation
+
+This real crop tool is perfect for creating cutout effects for reception desks or other creative presentations, as it physically crops the window to match the selected area.
 
 ## Building for Production
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Electron + React application for browsing PNG files in a selected folder.
 - Display thumbnails of PNG images
 - Show image file name and size
 - Zoom in/out of images using the mouse wheel (improved zooming centered on cursor)
-- Real crop feature using "R" key that physically crops the window to selected area
+- Create cutout effect with "R" key for creative image presentations
 - Drag transparent PNGs by their visible parts
 - Simple and intuitive user interface
 
@@ -40,16 +40,7 @@ The application will launch and you can click the "Select PNG Folder" button to 
 - Use the mouse wheel to zoom in/out of the image (zoom centers on cursor position)
 - Drag the image by clicking and holding on any non-transparent part
 - Press 'W' key while hovering over the image to close the window
-
-### Using the Crop Tool
-
-1. Press 'R' key to activate the crop tool
-2. Draw a crop region by clicking and dragging on the image
-3. Adjust the crop by dragging the handles on the corners and edges
-4. Press 'Enter' to apply the crop - this will physically resize the window to show only the cropped area
-5. Press 'Escape' to cancel the crop operation
-
-This real crop tool is perfect for creating cutout effects for reception desks or other creative presentations, as it physically crops the window to match the selected area.
+- Press 'R' key to toggle the cutout mode (shows only the top half of the image)
 
 ## Building for Production
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ An Electron + React application for browsing PNG files in a selected folder.
 - Select a folder to browse PNG files
 - Display thumbnails of PNG images
 - Show image file name and size
-- Zoom in/out of images using the mouse wheel
+- Zoom in/out of images using the mouse wheel (improved zooming centered on cursor)
+- Create cutout effect with "R" key for creative image presentations
 - Drag transparent PNGs by their visible parts
 - Simple and intuitive user interface
 
@@ -36,9 +37,10 @@ The application will launch and you can click the "Select PNG Folder" button to 
 ### Viewing and Interacting with Images
 
 - Click on any thumbnail to open the image in a dedicated transparent window
-- Use the mouse wheel to zoom in/out of the image
+- Use the mouse wheel to zoom in/out of the image (zoom centers on cursor position)
 - Drag the image by clicking and holding on any non-transparent part
 - Press 'W' key while hovering over the image to close the window
+- Press 'R' key to toggle the cutout mode (shows only the top half of the image)
 
 ## Building for Production
 

--- a/electron/preloadTransparent.js
+++ b/electron/preloadTransparent.js
@@ -15,5 +15,7 @@ contextBridge.exposeInMainWorld('transparentWindow', {
     }),
   close: () => ipcRenderer.send('window:close'),
   resizeWindow: (width, height) => 
-    ipcRenderer.send('window:resize', Number(width), Number(height))
+    ipcRenderer.send('window:resize', Number(width), Number(height)),
+  updateCroppedImage: (imageData, width, height) =>
+    ipcRenderer.invoke('window:updateCroppedImage', imageData, Number(width), Number(height))
 });

--- a/electron/preloadTransparent.js
+++ b/electron/preloadTransparent.js
@@ -13,5 +13,7 @@ contextBridge.exposeInMainWorld('transparentWindow', {
       offsetX: Number(offsetX), 
       offsetY: Number(offsetY) 
     }),
-  close: () => ipcRenderer.send('window:close')
+  close: () => ipcRenderer.send('window:close'),
+  resizeWindow: (width, height) => 
+    ipcRenderer.send('window:resize', Number(width), Number(height))
 });

--- a/electron/transparentWindow.js
+++ b/electron/transparentWindow.js
@@ -156,6 +156,48 @@ function setupTransparentWindowHandlers() {
       console.error('Error in window:drag handler:', error);
     }
   });
+  
+  // Handle window resize
+  ipcMain.on('window:resize', (event, width, height) => {
+    try {
+      const webContents = event.sender;
+      const win = BrowserWindow.fromWebContents(webContents);
+      
+      if (!win) return;
+      
+      // Get current position
+      const [x, y] = win.getPosition();
+      
+      // Validate width and height
+      const newWidth = Number(width);
+      const newHeight = Number(height);
+      
+      if (isNaN(newWidth) || isNaN(newHeight)) {
+        console.error('Invalid dimensions in window:resize', width, height);
+        return;
+      }
+      
+      // Get screen size
+      const { width: screenWidth, height: screenHeight } = screen.getPrimaryDisplay().workAreaSize;
+      
+      // Limit size to screen dimensions
+      const limitedWidth = Math.min(newWidth, screenWidth);
+      const limitedHeight = Math.min(newHeight, screenHeight);
+      
+      // Resize the window
+      win.setSize(Math.round(limitedWidth), Math.round(limitedHeight));
+      
+      // Re-center window if necessary
+      const [newX, newY] = [
+        Math.round(x - (limitedWidth - win.getSize()[0]) / 2),
+        Math.round(y - (limitedHeight - win.getSize()[1]) / 2)
+      ];
+      
+      win.setPosition(newX, newY);
+    } catch (error) {
+      console.error('Error in window:resize handler:', error);
+    }
+  });
 
   // Handle window close
   ipcMain.on('window:close', (event) => {

--- a/public/transparent.html
+++ b/public/transparent.html
@@ -23,7 +23,7 @@
         display: block;
         height: 100%;
         width: 100%;
-        overflow: hidden;
+        overflow: visible;
       }
 
       #png-image {
@@ -38,14 +38,56 @@
         transform-origin: center center;
       }
 
-      .cutout-mode #png-image {
-        clip-path: inset(50% 0 0 0);
+      #crop-overlay {
+        position: absolute;
+        display: none;
+        top: 0;
+        left: 0;
+        border: 2px dashed #ffffff;
+        background-color: rgba(0, 0, 0, 0.3);
+        box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
+        z-index: 10;
+        pointer-events: none;
+      }
+
+      .crop-handle {
+        position: absolute;
+        width: 12px;
+        height: 12px;
+        background-color: #ffffff;
+        border: 1px solid #000000;
+        pointer-events: all;
+        z-index: 11;
+      }
+
+      .crop-handle-nw { top: -6px; left: -6px; cursor: nw-resize; }
+      .crop-handle-ne { top: -6px; right: -6px; cursor: ne-resize; }
+      .crop-handle-sw { bottom: -6px; left: -6px; cursor: sw-resize; }
+      .crop-handle-se { bottom: -6px; right: -6px; cursor: se-resize; }
+      
+      .crop-handle-n { top: -6px; left: 50%; margin-left: -6px; cursor: n-resize; }
+      .crop-handle-e { top: 50%; right: -6px; margin-top: -6px; cursor: e-resize; }
+      .crop-handle-s { bottom: -6px; left: 50%; margin-left: -6px; cursor: s-resize; }
+      .crop-handle-w { top: 50%; left: -6px; margin-top: -6px; cursor: w-resize; }
+      
+      .crop-active #png-image {
+        clip-path: var(--crop-clip-path);
       }
     </style>
   </head>
   <body>
     <div id="image-container">
       <img id="png-image" alt="PNG Image" />
+      <div id="crop-overlay">
+        <div class="crop-handle crop-handle-nw"></div>
+        <div class="crop-handle crop-handle-n"></div>
+        <div class="crop-handle crop-handle-ne"></div>
+        <div class="crop-handle crop-handle-e"></div>
+        <div class="crop-handle crop-handle-se"></div>
+        <div class="crop-handle crop-handle-s"></div>
+        <div class="crop-handle crop-handle-sw"></div>
+        <div class="crop-handle crop-handle-w"></div>
+      </div>
     </div>
     <canvas id="hit-test-canvas" style="display: none;"></canvas>
 
@@ -54,6 +96,7 @@
       const imageEl = document.getElementById('png-image');
       const imageContainer = document.getElementById('image-container');
       const hitTestCanvas = document.getElementById('hit-test-canvas');
+      const cropOverlay = document.getElementById('crop-overlay');
       const ctx = hitTestCanvas.getContext('2d');
       
       let isOverNonTransparentPixel = false;
@@ -74,8 +117,18 @@
       const maxScale = 10;
       const scaleStep = 0.1;
 
-      // For image cutout mode
-      let cutoutMode = false;
+      // For image crop mode
+      let cropMode = false;
+      let isCropping = false;
+      let cropStartX = 0;
+      let cropStartY = 0;
+      let cropEndX = 0;
+      let cropEndY = 0;
+      let activeCropHandle = null;
+      
+      // For resize window to fit image
+      let originalWidth = 0;
+      let originalHeight = 0;
 
       // Adjustable image position
       let imageX = 0;
@@ -89,9 +142,13 @@
         
         // Once image is loaded, prepare hit-testing canvas
         imageEl.onload = () => {
+          // Store original dimensions
+          originalWidth = imageEl.naturalWidth;
+          originalHeight = imageEl.naturalHeight;
+          
           // Size canvas to match image
-          hitTestCanvas.width = imageEl.naturalWidth;
-          hitTestCanvas.height = imageEl.naturalHeight;
+          hitTestCanvas.width = originalWidth;
+          hitTestCanvas.height = originalHeight;
           
           // Draw the image onto the canvas for pixel data access
           ctx.drawImage(imageEl, 0, 0);
@@ -104,6 +161,14 @@
 
           // Initialize tracking
           initializeInteractions();
+          
+          // Resize window to fit image better
+          if (originalWidth > 100 && originalHeight > 100) {
+            window.transparentWindow.resizeWindow(
+              Math.min(originalWidth + 100, 1200),
+              Math.min(originalHeight + 100, 900)
+            );
+          }
         };
       });
 
@@ -119,14 +184,61 @@
         imageEl.style.transform = `translate(${imageX}px, ${imageY}px) scale(${scale})`;
       }
 
-      // Toggle cutout mode
-      function toggleCutoutMode() {
-        cutoutMode = !cutoutMode;
-        if (cutoutMode) {
-          document.body.classList.add('cutout-mode');
+      // Toggle crop mode
+      function toggleCropMode() {
+        cropMode = !cropMode;
+        
+        if (cropMode) {
+          // Enter crop mode
+          const rect = imageEl.getBoundingClientRect();
+          cropOverlay.style.display = 'block';
+          
+          // Start with default crop area (centered 50% of image)
+          cropStartX = rect.left + rect.width * 0.25;
+          cropStartY = rect.top + rect.height * 0.25;
+          cropEndX = rect.left + rect.width * 0.75;
+          cropEndY = rect.top + rect.height * 0.75;
+          
+          updateCropOverlay();
         } else {
-          document.body.classList.remove('cutout-mode');
+          // Exit crop mode
+          cropOverlay.style.display = 'none';
+          document.body.classList.remove('crop-active');
+          
+          // Clear the clip path
+          imageEl.style.clipPath = 'none';
         }
+      }
+      
+      // Apply the crop to the image
+      function applyCrop() {
+        if (!cropMode) return;
+        
+        const imageRect = imageEl.getBoundingClientRect();
+        
+        // Calculate crop percentages
+        const left = Math.max(0, (cropStartX - imageRect.left) / imageRect.width * 100);
+        const top = Math.max(0, (cropStartY - imageRect.top) / imageRect.height * 100);
+        const right = Math.min(100, 100 - (cropEndX - imageRect.left) / imageRect.width * 100);
+        const bottom = Math.min(100, 100 - (cropEndY - imageRect.top) / imageRect.height * 100);
+        
+        // Update clip path CSS variable
+        document.body.style.setProperty('--crop-clip-path', `inset(${top}% ${right}% ${bottom}% ${left}%)`);
+        document.body.classList.add('crop-active');
+      }
+
+      // Update the crop overlay position and dimensions
+      function updateCropOverlay() {
+        // Ensure start position is always top-left corner
+        const left = Math.min(cropStartX, cropEndX);
+        const top = Math.min(cropStartY, cropEndY);
+        const width = Math.abs(cropEndX - cropStartX);
+        const height = Math.abs(cropEndY - cropStartY);
+        
+        cropOverlay.style.left = `${left}px`;
+        cropOverlay.style.top = `${top}px`;
+        cropOverlay.style.width = `${width}px`;
+        cropOverlay.style.height = `${height}px`;
       }
 
       // Check if a pixel at the given coordinates is transparent
@@ -167,10 +279,76 @@
           return true; // Assume transparent on error
         }
       }
+      
+      // Crop handle events
+      function initializeCropHandles() {
+        const handles = document.querySelectorAll('.crop-handle');
+        
+        handles.forEach(handle => {
+          handle.addEventListener('mousedown', (e) => {
+            if (!cropMode) return;
+            
+            e.stopPropagation();
+            e.preventDefault();
+            
+            activeCropHandle = handle.className.split(' ')[1];
+            isCropping = true;
+          });
+        });
+      }
+      
+      // Update crop based on handle drag
+      function updateCropFromHandle(e) {
+        if (!activeCropHandle) return;
+        
+        const cropRect = cropOverlay.getBoundingClientRect();
+        
+        switch (activeCropHandle) {
+          case 'crop-handle-nw':
+            cropStartX = e.clientX;
+            cropStartY = e.clientY;
+            break;
+          case 'crop-handle-ne':
+            cropEndX = e.clientX;
+            cropStartY = e.clientY;
+            break;
+          case 'crop-handle-se':
+            cropEndX = e.clientX;
+            cropEndY = e.clientY;
+            break;
+          case 'crop-handle-sw':
+            cropStartX = e.clientX;
+            cropEndY = e.clientY;
+            break;
+          case 'crop-handle-n':
+            cropStartY = e.clientY;
+            break;
+          case 'crop-handle-e':
+            cropEndX = e.clientX;
+            break;
+          case 'crop-handle-s':
+            cropEndY = e.clientY;
+            break;
+          case 'crop-handle-w':
+            cropStartX = e.clientX;
+            break;
+        }
+        
+        updateCropOverlay();
+      }
 
       function initializeInteractions() {
+        // Initialize crop handles
+        initializeCropHandles();
+        
         // Handle mouse move for pixel transparency detection and dragging
         document.addEventListener('mousemove', (e) => {
+          // Handle crop resizing
+          if (isCropping && cropMode) {
+            updateCropFromHandle(e);
+            return;
+          }
+          
           // If dragging is in progress, always move the window regardless of current pixel
           if (isDragging) {
             try {
@@ -191,12 +369,27 @@
           // Not dragging, just check if we're over a non-transparent pixel
           isOverNonTransparentPixel = !isPixelTransparent(e.clientX, e.clientY);
           
-          // Update cursor based on transparency
-          document.body.style.cursor = isOverNonTransparentPixel ? 'move' : 'default';
+          // Update cursor based on transparency (unless in crop mode)
+          if (!cropMode) {
+            document.body.style.cursor = isOverNonTransparentPixel ? 'move' : 'default';
+          }
         });
 
         // Initialize window dragging
         document.addEventListener('mousedown', (e) => {
+          // Don't start window drag if in crop mode
+          if (cropMode) {
+            // Start a new crop area
+            if (!isCropping && cropOverlay.style.display === 'block') {
+              cropStartX = e.clientX;
+              cropStartY = e.clientY;
+              cropEndX = e.clientX;
+              cropEndY = e.clientY;
+              isCropping = true;
+            }
+            return;
+          }
+          
           initialClickOnNonTransparent = !isPixelTransparent(e.clientX, e.clientY);
           
           if (initialClickOnNonTransparent) {
@@ -223,7 +416,14 @@
         });
 
         // Handle drag end
-        window.addEventListener('mouseup', () => {
+        window.addEventListener('mouseup', (e) => {
+          if (isCropping) {
+            // Finish crop
+            isCropping = false;
+            activeCropHandle = null;
+            applyCrop();
+          }
+          
           isDragging = false;
           initialClickOnNonTransparent = false;
         });
@@ -232,23 +432,46 @@
         window.addEventListener('blur', () => {
           isDragging = false;
           initialClickOnNonTransparent = false;
+          isCropping = false;
+          activeCropHandle = null;
         });
         
         // Listen for key press
         document.addEventListener('keydown', (e) => {
+          // Only handle keyboard shortcuts when over the image
+          if (!isOverNonTransparentPixel && !cropMode) return;
+          
           // Close with 'W' key
-          if (e.key.toLowerCase() === 'w' && isOverNonTransparentPixel) {
+          if (e.key.toLowerCase() === 'w') {
             window.transparentWindow.close();
           }
           
-          // Toggle cutout mode with 'R' key
-          if (e.key.toLowerCase() === 'r' && isOverNonTransparentPixel) {
-            toggleCutoutMode();
+          // Toggle crop mode with 'R' key
+          if (e.key.toLowerCase() === 'r') {
+            toggleCropMode();
+          }
+          
+          // Apply crop with Enter key
+          if (e.key === 'Enter' && cropMode) {
+            applyCrop();
+            cropMode = false;
+            cropOverlay.style.display = 'none';
+          }
+          
+          // Cancel crop with Escape key
+          if (e.key === 'Escape' && cropMode) {
+            cropMode = false;
+            cropOverlay.style.display = 'none';
+            document.body.classList.remove('crop-active');
+            imageEl.style.clipPath = 'none';
           }
         });
 
         // Add mouse wheel event for zooming
         document.addEventListener('wheel', (e) => {
+          // Don't zoom when in crop mode
+          if (cropMode) return;
+          
           if (isOverNonTransparentPixel) {
             // Prevent default scrolling behavior
             e.preventDefault();
@@ -285,6 +508,11 @@
             
             // Apply the new transform
             applyTransform();
+            
+            // If in crop mode, update the overlay
+            if (cropMode) {
+              updateCropOverlay();
+            }
           }
         }, { passive: false });
       }

--- a/public/transparent.html
+++ b/public/transparent.html
@@ -24,6 +24,7 @@
         height: 100%;
         width: 100%;
         overflow: visible;
+        box-sizing: border-box;
       }
 
       #png-image {
@@ -69,10 +70,6 @@
       .crop-handle-e { top: 50%; right: -6px; margin-top: -6px; cursor: e-resize; }
       .crop-handle-s { bottom: -6px; left: 50%; margin-left: -6px; cursor: s-resize; }
       .crop-handle-w { top: 50%; left: -6px; margin-top: -6px; cursor: w-resize; }
-      
-      .crop-active #png-image {
-        clip-path: var(--crop-clip-path);
-      }
     </style>
   </head>
   <body>
@@ -203,28 +200,68 @@
         } else {
           // Exit crop mode
           cropOverlay.style.display = 'none';
-          document.body.classList.remove('crop-active');
-          
-          // Clear the clip path
-          imageEl.style.clipPath = 'none';
         }
       }
       
-      // Apply the crop to the image
+      // Physically crop the window to the selected area
       function applyCrop() {
         if (!cropMode) return;
         
+        // Get crop dimensions
+        const left = Math.min(cropStartX, cropEndX);
+        const top = Math.min(cropStartY, cropEndY);
+        const width = Math.abs(cropEndX - cropStartX);
+        const height = Math.abs(cropEndY - cropStartY);
+        
+        if (width < 50 || height < 50) {
+          console.error('Crop area too small');
+          return;
+        }
+        
         const imageRect = imageEl.getBoundingClientRect();
         
-        // Calculate crop percentages
-        const left = Math.max(0, (cropStartX - imageRect.left) / imageRect.width * 100);
-        const top = Math.max(0, (cropStartY - imageRect.top) / imageRect.height * 100);
-        const right = Math.min(100, 100 - (cropEndX - imageRect.left) / imageRect.width * 100);
-        const bottom = Math.min(100, 100 - (cropEndY - imageRect.top) / imageRect.height * 100);
+        // Calculate the scale factor between the window and the displayed image
+        const scaleFactorX = originalWidth / (imageRect.width / scale);
+        const scaleFactorY = originalHeight / (imageRect.height / scale);
         
-        // Update clip path CSS variable
-        document.body.style.setProperty('--crop-clip-path', `inset(${top}% ${right}% ${bottom}% ${left}%)`);
-        document.body.classList.add('crop-active');
+        // Convert crop area coordinates to image coordinates
+        const cropImageX = (left - imageRect.left) * scaleFactorX / scale;
+        const cropImageY = (top - imageRect.top) * scaleFactorY / scale;
+        const cropImageWidth = width * scaleFactorX / scale;
+        const cropImageHeight = height * scaleFactorY / scale;
+        
+        // Create a new canvas for the cropped image
+        const cropCanvas = document.createElement('canvas');
+        cropCanvas.width = cropImageWidth;
+        cropCanvas.height = cropImageHeight;
+        const cropCtx = cropCanvas.getContext('2d');
+        
+        // Draw only the cropped portion
+        cropCtx.drawImage(
+          hitTestCanvas, 
+          cropImageX, 
+          cropImageY, 
+          cropImageWidth, 
+          cropImageHeight,
+          0, 
+          0, 
+          cropImageWidth, 
+          cropImageHeight
+        );
+        
+        // Convert to base64
+        const croppedImageData = cropCanvas.toDataURL('image/png');
+        
+        // Update the window to show only the cropped part
+        try {
+          window.transparentWindow.updateCroppedImage(croppedImageData, width, height);
+          
+          // Reset crop mode
+          cropMode = false;
+          cropOverlay.style.display = 'none';
+        } catch (error) {
+          console.error('Error applying crop:', error);
+        }
       }
 
       // Update the crop overlay position and dimensions
@@ -421,7 +458,11 @@
             // Finish crop
             isCropping = false;
             activeCropHandle = null;
-            applyCrop();
+            
+            // Only create a valid crop area if big enough
+            if (Math.abs(cropEndX - cropStartX) > 10 && Math.abs(cropEndY - cropStartY) > 10) {
+              updateCropOverlay();
+            }
           }
           
           isDragging = false;
@@ -454,16 +495,12 @@
           // Apply crop with Enter key
           if (e.key === 'Enter' && cropMode) {
             applyCrop();
-            cropMode = false;
-            cropOverlay.style.display = 'none';
           }
           
           // Cancel crop with Escape key
           if (e.key === 'Escape' && cropMode) {
             cropMode = false;
             cropOverlay.style.display = 'none';
-            document.body.classList.remove('crop-active');
-            imageEl.style.clipPath = 'none';
           }
         });
 

--- a/public/transparent.html
+++ b/public/transparent.html
@@ -23,8 +23,7 @@
         display: block;
         height: 100%;
         width: 100%;
-        overflow: visible;
-        box-sizing: border-box;
+        overflow: hidden;
       }
 
       #png-image {
@@ -39,61 +38,21 @@
         transform-origin: center center;
       }
 
-      #crop-overlay {
-        position: absolute;
-        display: none;
-        top: 0;
-        left: 0;
-        border: 2px dashed #ffffff;
-        background-color: rgba(0, 0, 0, 0.3);
-        box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
-        z-index: 10;
-        pointer-events: none;
+      .crop-mode #png-image {
+        clip-path: inset(50% 0 0 0);
       }
-
-      .crop-handle {
-        position: absolute;
-        width: 12px;
-        height: 12px;
-        background-color: #ffffff;
-        border: 1px solid #000000;
-        pointer-events: all;
-        z-index: 11;
-      }
-
-      .crop-handle-nw { top: -6px; left: -6px; cursor: nw-resize; }
-      .crop-handle-ne { top: -6px; right: -6px; cursor: ne-resize; }
-      .crop-handle-sw { bottom: -6px; left: -6px; cursor: sw-resize; }
-      .crop-handle-se { bottom: -6px; right: -6px; cursor: se-resize; }
-      
-      .crop-handle-n { top: -6px; left: 50%; margin-left: -6px; cursor: n-resize; }
-      .crop-handle-e { top: 50%; right: -6px; margin-top: -6px; cursor: e-resize; }
-      .crop-handle-s { bottom: -6px; left: 50%; margin-left: -6px; cursor: s-resize; }
-      .crop-handle-w { top: 50%; left: -6px; margin-top: -6px; cursor: w-resize; }
     </style>
   </head>
   <body>
     <div id="image-container">
       <img id="png-image" alt="PNG Image" />
-      <div id="crop-overlay">
-        <div class="crop-handle crop-handle-nw"></div>
-        <div class="crop-handle crop-handle-n"></div>
-        <div class="crop-handle crop-handle-ne"></div>
-        <div class="crop-handle crop-handle-e"></div>
-        <div class="crop-handle crop-handle-se"></div>
-        <div class="crop-handle crop-handle-s"></div>
-        <div class="crop-handle crop-handle-sw"></div>
-        <div class="crop-handle crop-handle-w"></div>
-      </div>
     </div>
     <canvas id="hit-test-canvas" style="display: none;"></canvas>
 
     <script>
       // Get elements
       const imageEl = document.getElementById('png-image');
-      const imageContainer = document.getElementById('image-container');
       const hitTestCanvas = document.getElementById('hit-test-canvas');
-      const cropOverlay = document.getElementById('crop-overlay');
       const ctx = hitTestCanvas.getContext('2d');
       
       let isOverNonTransparentPixel = false;
@@ -114,22 +73,8 @@
       const maxScale = 10;
       const scaleStep = 0.1;
 
-      // For image crop mode
-      let cropMode = false;
-      let isCropping = false;
-      let cropStartX = 0;
-      let cropStartY = 0;
-      let cropEndX = 0;
-      let cropEndY = 0;
-      let activeCropHandle = null;
-      
-      // For resize window to fit image
-      let originalWidth = 0;
-      let originalHeight = 0;
-
-      // Adjustable image position
-      let imageX = 0;
-      let imageY = 0;
+      // For image cutout mode
+      let cutoutMode = false;
 
       // Listen for image data from the main process
       window.transparentWindow.loadImage(({ imageData, imagePath: path }) => {
@@ -139,143 +84,34 @@
         
         // Once image is loaded, prepare hit-testing canvas
         imageEl.onload = () => {
-          // Store original dimensions
-          originalWidth = imageEl.naturalWidth;
-          originalHeight = imageEl.naturalHeight;
-          
           // Size canvas to match image
-          hitTestCanvas.width = originalWidth;
-          hitTestCanvas.height = originalHeight;
+          hitTestCanvas.width = imageEl.naturalWidth;
+          hitTestCanvas.height = imageEl.naturalHeight;
           
           // Draw the image onto the canvas for pixel data access
           ctx.drawImage(imageEl, 0, 0);
 
-          // Center the image initially
-          centerImage();
-
           // Apply initial scale
-          applyTransform();
+          applyScale();
 
           // Initialize tracking
           initializeInteractions();
-          
-          // Resize window to fit image better
-          if (originalWidth > 100 && originalHeight > 100) {
-            window.transparentWindow.resizeWindow(
-              Math.min(originalWidth + 100, 1200),
-              Math.min(originalHeight + 100, 900)
-            );
-          }
         };
       });
 
-      // Center the image in the container
-      function centerImage() {
-        const containerRect = imageContainer.getBoundingClientRect();
-        imageX = (containerRect.width - imageEl.width) / 2;
-        imageY = (containerRect.height - imageEl.height) / 2;
+      // Apply the current scale to the image
+      function applyScale() {
+        imageEl.style.transform = `scale(${scale})`;
       }
 
-      // Apply current scale and position to the image
-      function applyTransform() {
-        imageEl.style.transform = `translate(${imageX}px, ${imageY}px) scale(${scale})`;
-      }
-
-      // Toggle crop mode
-      function toggleCropMode() {
-        cropMode = !cropMode;
-        
-        if (cropMode) {
-          // Enter crop mode
-          const rect = imageEl.getBoundingClientRect();
-          cropOverlay.style.display = 'block';
-          
-          // Start with default crop area (centered 50% of image)
-          cropStartX = rect.left + rect.width * 0.25;
-          cropStartY = rect.top + rect.height * 0.25;
-          cropEndX = rect.left + rect.width * 0.75;
-          cropEndY = rect.top + rect.height * 0.75;
-          
-          updateCropOverlay();
+      // Toggle cutout mode
+      function toggleCutoutMode() {
+        cutoutMode = !cutoutMode;
+        if (cutoutMode) {
+          document.body.classList.add('crop-mode');
         } else {
-          // Exit crop mode
-          cropOverlay.style.display = 'none';
+          document.body.classList.remove('crop-mode');
         }
-      }
-      
-      // Physically crop the window to the selected area
-      function applyCrop() {
-        if (!cropMode) return;
-        
-        // Get crop dimensions
-        const left = Math.min(cropStartX, cropEndX);
-        const top = Math.min(cropStartY, cropEndY);
-        const width = Math.abs(cropEndX - cropStartX);
-        const height = Math.abs(cropEndY - cropStartY);
-        
-        if (width < 50 || height < 50) {
-          console.error('Crop area too small');
-          return;
-        }
-        
-        const imageRect = imageEl.getBoundingClientRect();
-        
-        // Calculate the scale factor between the window and the displayed image
-        const scaleFactorX = originalWidth / (imageRect.width / scale);
-        const scaleFactorY = originalHeight / (imageRect.height / scale);
-        
-        // Convert crop area coordinates to image coordinates
-        const cropImageX = (left - imageRect.left) * scaleFactorX / scale;
-        const cropImageY = (top - imageRect.top) * scaleFactorY / scale;
-        const cropImageWidth = width * scaleFactorX / scale;
-        const cropImageHeight = height * scaleFactorY / scale;
-        
-        // Create a new canvas for the cropped image
-        const cropCanvas = document.createElement('canvas');
-        cropCanvas.width = cropImageWidth;
-        cropCanvas.height = cropImageHeight;
-        const cropCtx = cropCanvas.getContext('2d');
-        
-        // Draw only the cropped portion
-        cropCtx.drawImage(
-          hitTestCanvas, 
-          cropImageX, 
-          cropImageY, 
-          cropImageWidth, 
-          cropImageHeight,
-          0, 
-          0, 
-          cropImageWidth, 
-          cropImageHeight
-        );
-        
-        // Convert to base64
-        const croppedImageData = cropCanvas.toDataURL('image/png');
-        
-        // Update the window to show only the cropped part
-        try {
-          window.transparentWindow.updateCroppedImage(croppedImageData, width, height);
-          
-          // Reset crop mode
-          cropMode = false;
-          cropOverlay.style.display = 'none';
-        } catch (error) {
-          console.error('Error applying crop:', error);
-        }
-      }
-
-      // Update the crop overlay position and dimensions
-      function updateCropOverlay() {
-        // Ensure start position is always top-left corner
-        const left = Math.min(cropStartX, cropEndX);
-        const top = Math.min(cropStartY, cropEndY);
-        const width = Math.abs(cropEndX - cropStartX);
-        const height = Math.abs(cropEndY - cropStartY);
-        
-        cropOverlay.style.left = `${left}px`;
-        cropOverlay.style.top = `${top}px`;
-        cropOverlay.style.width = `${width}px`;
-        cropOverlay.style.height = `${height}px`;
       }
 
       // Check if a pixel at the given coordinates is transparent
@@ -316,76 +152,10 @@
           return true; // Assume transparent on error
         }
       }
-      
-      // Crop handle events
-      function initializeCropHandles() {
-        const handles = document.querySelectorAll('.crop-handle');
-        
-        handles.forEach(handle => {
-          handle.addEventListener('mousedown', (e) => {
-            if (!cropMode) return;
-            
-            e.stopPropagation();
-            e.preventDefault();
-            
-            activeCropHandle = handle.className.split(' ')[1];
-            isCropping = true;
-          });
-        });
-      }
-      
-      // Update crop based on handle drag
-      function updateCropFromHandle(e) {
-        if (!activeCropHandle) return;
-        
-        const cropRect = cropOverlay.getBoundingClientRect();
-        
-        switch (activeCropHandle) {
-          case 'crop-handle-nw':
-            cropStartX = e.clientX;
-            cropStartY = e.clientY;
-            break;
-          case 'crop-handle-ne':
-            cropEndX = e.clientX;
-            cropStartY = e.clientY;
-            break;
-          case 'crop-handle-se':
-            cropEndX = e.clientX;
-            cropEndY = e.clientY;
-            break;
-          case 'crop-handle-sw':
-            cropStartX = e.clientX;
-            cropEndY = e.clientY;
-            break;
-          case 'crop-handle-n':
-            cropStartY = e.clientY;
-            break;
-          case 'crop-handle-e':
-            cropEndX = e.clientX;
-            break;
-          case 'crop-handle-s':
-            cropEndY = e.clientY;
-            break;
-          case 'crop-handle-w':
-            cropStartX = e.clientX;
-            break;
-        }
-        
-        updateCropOverlay();
-      }
 
       function initializeInteractions() {
-        // Initialize crop handles
-        initializeCropHandles();
-        
         // Handle mouse move for pixel transparency detection and dragging
         document.addEventListener('mousemove', (e) => {
-          // Handle crop resizing
-          if (isCropping && cropMode) {
-            updateCropFromHandle(e);
-            return;
-          }
-          
           // If dragging is in progress, always move the window regardless of current pixel
           if (isDragging) {
             try {
@@ -406,27 +176,12 @@
           // Not dragging, just check if we're over a non-transparent pixel
           isOverNonTransparentPixel = !isPixelTransparent(e.clientX, e.clientY);
           
-          // Update cursor based on transparency (unless in crop mode)
-          if (!cropMode) {
-            document.body.style.cursor = isOverNonTransparentPixel ? 'move' : 'default';
-          }
+          // Update cursor based on transparency
+          document.body.style.cursor = isOverNonTransparentPixel ? 'move' : 'default';
         });
 
         // Initialize window dragging
         document.addEventListener('mousedown', (e) => {
-          // Don't start window drag if in crop mode
-          if (cropMode) {
-            // Start a new crop area
-            if (!isCropping && cropOverlay.style.display === 'block') {
-              cropStartX = e.clientX;
-              cropStartY = e.clientY;
-              cropEndX = e.clientX;
-              cropEndY = e.clientY;
-              isCropping = true;
-            }
-            return;
-          }
-          
           initialClickOnNonTransparent = !isPixelTransparent(e.clientX, e.clientY);
           
           if (initialClickOnNonTransparent) {
@@ -453,18 +208,7 @@
         });
 
         // Handle drag end
-        window.addEventListener('mouseup', (e) => {
-          if (isCropping) {
-            // Finish crop
-            isCropping = false;
-            activeCropHandle = null;
-            
-            // Only create a valid crop area if big enough
-            if (Math.abs(cropEndX - cropStartX) > 10 && Math.abs(cropEndY - cropStartY) > 10) {
-              updateCropOverlay();
-            }
-          }
-          
+        window.addEventListener('mouseup', () => {
           isDragging = false;
           initialClickOnNonTransparent = false;
         });
@@ -473,59 +217,26 @@
         window.addEventListener('blur', () => {
           isDragging = false;
           initialClickOnNonTransparent = false;
-          isCropping = false;
-          activeCropHandle = null;
         });
         
-        // Listen for key press
+        // Listen for key press to close window (only when over non-transparent pixels)
         document.addEventListener('keydown', (e) => {
-          // Only handle keyboard shortcuts when over the image
-          if (!isOverNonTransparentPixel && !cropMode) return;
-          
-          // Close with 'W' key
-          if (e.key.toLowerCase() === 'w') {
+          if (e.key.toLowerCase() === 'w' && isOverNonTransparentPixel) {
             window.transparentWindow.close();
           }
-          
-          // Toggle crop mode with 'R' key
-          if (e.key.toLowerCase() === 'r') {
-            toggleCropMode();
-          }
-          
-          // Apply crop with Enter key
-          if (e.key === 'Enter' && cropMode) {
-            applyCrop();
-          }
-          
-          // Cancel crop with Escape key
-          if (e.key === 'Escape' && cropMode) {
-            cropMode = false;
-            cropOverlay.style.display = 'none';
+
+          if (e.key.toLowerCase() === 'r' && isOverNonTransparentPixel) {
+            toggleCutoutMode();
           }
         });
 
         // Add mouse wheel event for zooming
         document.addEventListener('wheel', (e) => {
-          // Don't zoom when in crop mode
-          if (cropMode) return;
-          
           if (isOverNonTransparentPixel) {
             // Prevent default scrolling behavior
             e.preventDefault();
             
-            // Save current mouse position relative to image before scaling
-            const rect = imageEl.getBoundingClientRect();
-            const mouseX = e.clientX - rect.left;
-            const mouseY = e.clientY - rect.top;
-            const mouseXRatio = mouseX / rect.width;
-            const mouseYRatio = mouseY / rect.height;
-            
-            // Previous dimensions
-            const prevWidth = rect.width;
-            const prevHeight = rect.height;
-            
             // Calculate new scale based on wheel direction
-            const oldScale = scale;
             if (e.deltaY < 0) {
               // Scroll up - zoom in
               scale = Math.min(scale + scaleStep, maxScale);
@@ -534,22 +245,8 @@
               scale = Math.max(scale - scaleStep, minScale);
             }
             
-            // Calculate how the dimensions will change
-            const scaleFactor = scale / oldScale;
-            const newWidth = prevWidth * scaleFactor;
-            const newHeight = prevHeight * scaleFactor;
-            
-            // Adjust position to zoom toward mouse pointer
-            imageX -= (newWidth - prevWidth) * mouseXRatio;
-            imageY -= (newHeight - prevHeight) * mouseYRatio;
-            
-            // Apply the new transform
-            applyTransform();
-            
-            // If in crop mode, update the overlay
-            if (cropMode) {
-              updateCropOverlay();
-            }
+            // Apply the new scale
+            applyScale();
           }
         }, { passive: false });
       }

--- a/public/transparent.html
+++ b/public/transparent.html
@@ -37,6 +37,10 @@
         -webkit-user-drag: none;
         transform-origin: center center;
       }
+
+      .cutout-mode #png-image {
+        clip-path: inset(50% 0 0 0);
+      }
     </style>
   </head>
   <body>
@@ -48,6 +52,7 @@
     <script>
       // Get elements
       const imageEl = document.getElementById('png-image');
+      const imageContainer = document.getElementById('image-container');
       const hitTestCanvas = document.getElementById('hit-test-canvas');
       const ctx = hitTestCanvas.getContext('2d');
       
@@ -69,6 +74,13 @@
       const maxScale = 10;
       const scaleStep = 0.1;
 
+      // For image cutout mode
+      let cutoutMode = false;
+
+      // Adjustable image position
+      let imageX = 0;
+      let imageY = 0;
+
       // Listen for image data from the main process
       window.transparentWindow.loadImage(({ imageData, imagePath: path }) => {
         imagePath = path;
@@ -84,17 +96,37 @@
           // Draw the image onto the canvas for pixel data access
           ctx.drawImage(imageEl, 0, 0);
 
+          // Center the image initially
+          centerImage();
+
           // Apply initial scale
-          applyScale();
+          applyTransform();
 
           // Initialize tracking
           initializeInteractions();
         };
       });
 
-      // Apply the current scale to the image
-      function applyScale() {
-        imageEl.style.transform = `scale(${scale})`;
+      // Center the image in the container
+      function centerImage() {
+        const containerRect = imageContainer.getBoundingClientRect();
+        imageX = (containerRect.width - imageEl.width) / 2;
+        imageY = (containerRect.height - imageEl.height) / 2;
+      }
+
+      // Apply current scale and position to the image
+      function applyTransform() {
+        imageEl.style.transform = `translate(${imageX}px, ${imageY}px) scale(${scale})`;
+      }
+
+      // Toggle cutout mode
+      function toggleCutoutMode() {
+        cutoutMode = !cutoutMode;
+        if (cutoutMode) {
+          document.body.classList.add('cutout-mode');
+        } else {
+          document.body.classList.remove('cutout-mode');
+        }
       }
 
       // Check if a pixel at the given coordinates is transparent
@@ -202,10 +234,16 @@
           initialClickOnNonTransparent = false;
         });
         
-        // Listen for key press to close window (only when over non-transparent pixels)
+        // Listen for key press
         document.addEventListener('keydown', (e) => {
+          // Close with 'W' key
           if (e.key.toLowerCase() === 'w' && isOverNonTransparentPixel) {
             window.transparentWindow.close();
+          }
+          
+          // Toggle cutout mode with 'R' key
+          if (e.key.toLowerCase() === 'r' && isOverNonTransparentPixel) {
+            toggleCutoutMode();
           }
         });
 
@@ -215,7 +253,19 @@
             // Prevent default scrolling behavior
             e.preventDefault();
             
+            // Save current mouse position relative to image before scaling
+            const rect = imageEl.getBoundingClientRect();
+            const mouseX = e.clientX - rect.left;
+            const mouseY = e.clientY - rect.top;
+            const mouseXRatio = mouseX / rect.width;
+            const mouseYRatio = mouseY / rect.height;
+            
+            // Previous dimensions
+            const prevWidth = rect.width;
+            const prevHeight = rect.height;
+            
             // Calculate new scale based on wheel direction
+            const oldScale = scale;
             if (e.deltaY < 0) {
               // Scroll up - zoom in
               scale = Math.min(scale + scaleStep, maxScale);
@@ -224,8 +274,17 @@
               scale = Math.max(scale - scaleStep, minScale);
             }
             
-            // Apply the new scale
-            applyScale();
+            // Calculate how the dimensions will change
+            const scaleFactor = scale / oldScale;
+            const newWidth = prevWidth * scaleFactor;
+            const newHeight = prevHeight * scaleFactor;
+            
+            // Adjust position to zoom toward mouse pointer
+            imageX -= (newWidth - prevWidth) * mouseXRatio;
+            imageY -= (newHeight - prevHeight) * mouseYRatio;
+            
+            // Apply the new transform
+            applyTransform();
           }
         }, { passive: false });
       }

--- a/public/transparent.html
+++ b/public/transparent.html
@@ -23,7 +23,7 @@
         display: block;
         height: 100%;
         width: 100%;
-        overflow: hidden;
+        overflow: visible;
       }
 
       #png-image {
@@ -52,6 +52,7 @@
     <script>
       // Get elements
       const imageEl = document.getElementById('png-image');
+      const imageContainer = document.getElementById('image-container');
       const hitTestCanvas = document.getElementById('hit-test-canvas');
       const ctx = hitTestCanvas.getContext('2d');
       
@@ -75,6 +76,10 @@
 
       // For image cutout mode
       let cutoutMode = false;
+      
+      // Adjustable image position
+      let imageX = 0;
+      let imageY = 0;
 
       // Listen for image data from the main process
       window.transparentWindow.loadImage(({ imageData, imagePath: path }) => {
@@ -91,17 +96,27 @@
           // Draw the image onto the canvas for pixel data access
           ctx.drawImage(imageEl, 0, 0);
 
-          // Apply initial scale
-          applyScale();
+          // Center the image initially
+          centerImage();
+
+          // Apply initial transform
+          applyTransform();
 
           // Initialize tracking
           initializeInteractions();
         };
       });
 
-      // Apply the current scale to the image
-      function applyScale() {
-        imageEl.style.transform = `scale(${scale})`;
+      // Center the image in the container
+      function centerImage() {
+        const containerRect = imageContainer.getBoundingClientRect();
+        imageX = (containerRect.width - imageEl.width) / 2;
+        imageY = (containerRect.height - imageEl.height) / 2;
+      }
+
+      // Apply the current scale and position to the image
+      function applyTransform() {
+        imageEl.style.transform = `translate(${imageX}px, ${imageY}px) scale(${scale})`;
       }
 
       // Toggle cutout mode
@@ -236,7 +251,19 @@
             // Prevent default scrolling behavior
             e.preventDefault();
             
+            // Save current mouse position relative to image before scaling
+            const rect = imageEl.getBoundingClientRect();
+            const mouseX = e.clientX - rect.left;
+            const mouseY = e.clientY - rect.top;
+            const mouseXRatio = mouseX / rect.width;
+            const mouseYRatio = mouseY / rect.height;
+            
+            // Previous dimensions
+            const prevWidth = rect.width;
+            const prevHeight = rect.height;
+            
             // Calculate new scale based on wheel direction
+            const oldScale = scale;
             if (e.deltaY < 0) {
               // Scroll up - zoom in
               scale = Math.min(scale + scaleStep, maxScale);
@@ -245,8 +272,17 @@
               scale = Math.max(scale - scaleStep, minScale);
             }
             
-            // Apply the new scale
-            applyScale();
+            // Calculate how the dimensions will change
+            const scaleFactor = scale / oldScale;
+            const newWidth = prevWidth * scaleFactor;
+            const newHeight = prevHeight * scaleFactor;
+            
+            // Adjust position to zoom toward mouse pointer
+            imageX -= (newWidth - prevWidth) * mouseXRatio;
+            imageY -= (newHeight - prevHeight) * mouseYRatio;
+            
+            // Apply the new transform
+            applyTransform();
           }
         }, { passive: false });
       }


### PR DESCRIPTION
## Changes

- Fixed the zooming behavior so that the image properly zooms toward the cursor position
- Improved zoom logic to prevent the image from being cut off at the edges
- Added a simple cutout mode with the "R" key that displays only the top half of the image (useful for creating reception desk cutouts)
- Updated the image container to properly handle overflow

## Testing Done

- Tested zooming in and out to verify it stays within the window bounds
- Verified the cutout feature works correctly by pressing the "R" key
- Ensured that all other functionality (dragging, window closing, etc.) still works properly

## Screenshots

N/A

