### PR TITLE
Fix window size and add red outlines

### DIFF
--- a/electron/transparentWindow.js
+++ b/electron/transparentWindow.js
@@ -12,13 +12,13 @@ function createTransparentWindow(imagePath, imageId) {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
   
   // Create a new BrowserWindow with transparent background and no frame
-  // Using larger default size for better zooming experience
+  // Using fixed size window
   const transparentWindow = new BrowserWindow({
     width: 600,
     height: 600,
     transparent: true,
     frame: false,
-    resizable: true,
+    resizable: false, // Changed to false to prevent resizing
     skipTaskbar: true,
     hasShadow: false,
     // Disable resize animation to prevent momentary jumps
@@ -163,41 +163,10 @@ function setupTransparentWindowHandlers() {
     }
   });
 
-  // Handle window resize with combined position adjustment
+  // Handle window resize - disabled since we don't want resizing
   ipcMain.on('window:resize', (event, { width, height, keepCentered = true }) => {
-    try {
-      const webContents = event.sender;
-      const win = BrowserWindow.fromWebContents(webContents);
-      if (!win) return;
-      
-      // Ensure values are numbers and have minimums
-      const newWidth = Math.max(200, Number(width) || 600);
-      const newHeight = Math.max(200, Number(height) || 600);
-      
-      // Calculate position adjustments to maintain the same center
-      if (keepCentered) {
-        // Get current position and size
-        const [x, y] = win.getPosition();
-        const [oldWidth, oldHeight] = win.getSize();
-        
-        // Calculate position deltas to maintain center point
-        const deltaX = Math.floor((newWidth - oldWidth) / 2);
-        const deltaY = Math.floor((newHeight - oldHeight) / 2);
-        
-        // Set new position and size simultaneously to prevent flicker
-        win.setBounds({
-          x: x - deltaX,
-          y: y - deltaY,
-          width: newWidth,
-          height: newHeight
-        }, true); // true = animate (but animation is disabled in window config)
-      } else {
-        // Just resize without repositioning
-        win.setSize(Math.round(newWidth), Math.round(newHeight));
-      }
-    } catch (error) {
-      console.error('Error in window:resize handler:', error);
-    }
+    // Resizing is disabled to keep a consistent window size
+    return;
   });
 
   // Handle window close

--- a/public/transparent.html
+++ b/public/transparent.html
@@ -17,6 +17,9 @@
 
       body {
         user-select: none;
+        border: 2px solid #ff0000;
+        box-sizing: border-box;
+        border-radius: 4px;
       }
 
       #image-container {
@@ -36,6 +39,7 @@
         display: none;
         -webkit-user-drag: none;
         transform-origin: center center;
+        border: 2px solid #ff0000;
       }
 
       /* Add controls for better navigation */
@@ -135,17 +139,6 @@
           // Set initial scale
           updateScale();
           
-          // Set initial window size based on image dimensions
-          // IMPORTANT: We only set the window size ONCE, on initial load
-          const initialPadding = 50;
-          const initialWidth = Math.min(window.screen.availWidth * 0.9, 
-                                     imageEl.naturalWidth + initialPadding * 2);
-          const initialHeight = Math.min(window.screen.availHeight * 0.9, 
-                                      imageEl.naturalHeight + initialPadding * 2);
-          
-          // Set the window size once, then never change it
-          window.transparentWindow.resize(initialWidth, initialHeight, true);
-
           // Initialize interaction handlers
           initializeInteractions();
         };
@@ -301,8 +294,6 @@
             if (oldScale !== scale) {
               // Apply the new scale - this will scale from the center due to transform-origin
               updateScale();
-              
-              // NO WINDOW RESIZING - this eliminates the jumping
             }
           }
         }, { passive: false });


### PR DESCRIPTION
## Description
This PR adds red outlines to the transparent window and PNG images while fixing window size issues.

### Features Added
- Added 2px solid red outline to the transparent window
- Added 2px solid red outline to the PNG image itself
- Made transparent window fixed at 600x600 size, preventing resizing issues

### Technical changes
- Modified `transparentWindow.js` to set `resizable: false`
- Completely disabled the resize handler in window.resize
- Added CSS border styles for both the window and image
- Removed all code trying to resize the window

This implementation maintains the static 600x600 window size as defined in the codebase, making no changes to those values.